### PR TITLE
Add maxWidth and respect maxLen in readLine

### DIFF
--- a/qx82/internal/input.js
+++ b/qx82/internal/input.js
@@ -40,7 +40,7 @@ export class InputSys {
     });
   }
 
-  async readLine(initString, maxLen, maxWidth = 28) {
+  async readLine(initString, maxLen, maxWidth = -1) {
     const startCol = main.drawState.cursorCol;
     const startRow = main.drawState.cursorRow;
     let curCol = startCol;
@@ -73,10 +73,10 @@ export class InputSys {
         main.cursorRenderer.setCursorVisible(cursorWasVisible);
         return curStrings.join("");
       } else if (key.length === 1) {
-        if (curStrings[curPos].length < maxLen || maxLen === -1) {
+        if (curStrings.join("").length < maxLen || maxLen === -1) {
           curStrings[curPos] += key;
 
-          if (curStrings[curPos].length >= maxWidth) {
+          if (maxWidth !== -1 && curStrings[curPos].length >= maxWidth) {
             main.textRenderer.print(curStrings[curPos].charAt(curStrings[curPos].length-1));
             curCol = startCol;
             curPos++;

--- a/qx82/internal/input.js
+++ b/qx82/internal/input.js
@@ -11,7 +11,7 @@ export class InputSys {
     window.addEventListener("keyup", e => this.onKeyUp(e));
   }
 
-  keyHeld(keyName) { 
+  keyHeld(keyName) {
     return this.keysHeld_.has(keyName.toUpperCase());
   }
   // API function
@@ -72,15 +72,17 @@ export class InputSys {
         // Restore previous cursor state.
         main.cursorRenderer.setCursorVisible(cursorWasVisible);
         return curStrings.join("");
-      } else if (key.length === 1 && curStrings.join("").length < maxLen) {
-        curStrings[curPos] += key;
+      } else if (key.length === 1) {
+        if (curStrings[curPos].length < maxLen || maxLen === -1) {
+          curStrings[curPos] += key;
 
-        if (curStrings[curPos].length >= maxWidth) {
-          main.textRenderer.print(curStrings[curPos].charAt(curStrings[curPos].length-1));
-          curCol = startCol;
-          curPos++;
-          curStrings[curPos] = "";
-          curRow++;
+          if (curStrings[curPos].length >= maxWidth) {
+            main.textRenderer.print(curStrings[curPos].charAt(curStrings[curPos].length-1));
+            curCol = startCol;
+            curPos++;
+            curStrings[curPos] = "";
+            curRow++;
+          }
         }
       }
     }

--- a/qx82/qxa.js
+++ b/qx82/qxa.js
@@ -31,10 +31,11 @@ export async function key() {
 /// maxLen: integer (default -1)
 ///   The maximum length of the string the user can type.
 ///   If this is -1, this means there is no limit.
-/// maxWidth: integer (default = 28)
+/// maxWidth: integer (default = -1)
 ///   The maximum width of the input line, in characters.
-///   If the user types more, the text will wrap to the next line.
-export async function readLine(initString = "", maxLen = -1, maxWidth = 28) {
+///   When the user types more, the text will wrap to the next line.
+///   If this is -1, this means it won't wrap at all.
+export async function readLine(initString = "", maxLen = -1, maxWidth = -1) {
   main.preflight("readLine");
   qut.checkString("initString", initString);
   qut.checkNumber("maxLen", maxLen);

--- a/qx82/qxa.js
+++ b/qx82/qxa.js
@@ -31,6 +31,9 @@ export async function key() {
 /// maxLen: integer (default -1)
 ///   The maximum length of the string the user can type.
 ///   If this is -1, this means there is no limit.
+/// maxWidth: integer (default = 28)
+///   The maximum width of the input line, in characters.
+///   If the user types more, the text will wrap to the next line.
 export async function readLine(initString = "", maxLen = -1, maxWidth = 28) {
   main.preflight("readLine");
   qut.checkString("initString", initString);

--- a/qx82/qxa.js
+++ b/qx82/qxa.js
@@ -31,11 +31,11 @@ export async function key() {
 /// maxLen: integer (default -1)
 ///   The maximum length of the string the user can type.
 ///   If this is -1, this means there is no limit.
-export async function readLine(initString = "", maxLen = -1) {
+export async function readLine(initString = "", maxLen = -1, maxWidth = 28) {
   main.preflight("readLine");
   qut.checkString("initString", initString);
   qut.checkNumber("maxLen", maxLen);
-  return await main.inputSys.readLine(initString, maxLen);
+  return await main.inputSys.readLine(initString, maxLen, maxWidth);
 }
 
 /// Shows a menu of choices and waits for the user to pick an option.


### PR DESCRIPTION
Related to #8

Allows for setting a maximum width of characters for readLine. Which means if the user types beyond the maxWidth, it will move the cursor to the next line. It is currently set to default of 28 so that it aligns well with the "example-hello.html" example, but of course can be set to other values. For example, here is it set to 5 (`readLine("", -1, 5);`)
![image](https://github.com/btco/qx82/assets/1261392/42b13a21-824a-420c-a3a5-6f2fc0a7cfd3)

When you press "Enter", it will return the entire line as a single string with no newlines, so it will preserve the nature of readLine.

Also, made sure that it respects the value set for maxLen so that works now too 👍 

Feel free to adjust or change anything in my code! 