### PR TITLE
Fix stuck dirty flag when the 3D screen effect is enabled

### DIFF
--- a/qx82/internal/main.js
+++ b/qx82/internal/main.js
@@ -228,6 +228,7 @@ export function setFrameHandler(callback, targetFps) {
 
 export function render() {
   if (crashed) return;
+  dirty = false;
   if (tv3d) {
     tv3d.updateScreen();
     return;
@@ -236,7 +237,6 @@ export function render() {
   realCtx.clearRect(0, 0, realCanvas.width, realCanvas.height);
   realCtx.drawImage(canvas,
     0, 0, realCanvas.width, realCanvas.height)
-  dirty = false;
   cursorRenderer.drawCursor(realCtx, realCanvas.width, realCanvas.height);
 }
 


### PR DESCRIPTION
This PR fixes an issue that caused dirty to only be marked in `render()` when in 2d mode. This bug made the entire dirty-tracking system permanently disables itself after the first frame in tv3d mode.

I found this bug when trying to get a water flickering effect to work in my game, and noticed that it worked fine in 2d mode but not in 3d mode for some reason

Before:

https://github.com/user-attachments/assets/7d21dae4-25c4-4af0-a93a-3914aa07bbc0

After: 

https://github.com/user-attachments/assets/5ee2477a-89ac-405d-a5fb-8b6f2b093544



### Reproduction Steps
Use the below code with `THREE_SETTINGS` as default, then with `THREE_SETTINGS` set to null
When in tv3d mode, the counter stays at 0, but in 2d mode, it ticks up.
```
<script type="module">
  import * as qx from "./qx82/qx.js";
  import * as qxa from "./qx82/qxa.js";

  async function main() {
    let counter = 0;
    setInterval(() => { qx.locate(1, 1); qx.print(String(counter++)); }, 250);
  }

  window.addEventListener("load", () => qx.init(main));
</script>
```

With this PR, the counter will tick up properly in tv3d mode too